### PR TITLE
fix: On some Linux, `cc` expects the input argument to come before other options

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@ mod tests {
     use super::predicates::*;
     use super::*;
     use crate as inline_c;
-    use std::env::{remove_var, set_var};
 
     #[test]
     fn test_c_macro() {
@@ -81,6 +80,8 @@ mod tests {
     #[cfg(not(target_os = "windows"))]
     #[test]
     fn test_c_macro_with_env_vars_from_env_vars() {
+        use std::env::{remove_var, set_var};
+
         // Define env vars through env vars.
         set_var("INLINE_C_RS_FOO", "bar baz qux");
         set_var("INLINE_C_RS_HELLO", "World!");

--- a/src/run.rs
+++ b/src/run.rs
@@ -67,8 +67,8 @@ pub fn run(language: Language, program: &str) -> Result<Assert, Box<dyn Error>> 
     let compiler = build.try_get_compiler()?;
 
     let mut command = Command::new(compiler.path());
-    command.arg(input_path.clone()); // the input must come first
     command.args(compiler.args());
+    command.arg(input_path.clone()); // the input must come first
     command_add_compiler_flags(&mut command, &variables);
     command_add_output_file(&mut command, &output_path, msvc, compiler.is_like_clang());
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -38,8 +38,9 @@ pub fn run(language: Language, program: &str) -> Result<Assert, Box<dyn Error>> 
     let mut output_temp = tempfile::Builder::new();
     let output_temp = output_temp.prefix("inline-c-rs-");
 
-    #[cfg(target_os = "windows")]
-    output_temp.suffix(".exe");
+    if msvc {
+        output_temp.suffix(".exe");
+    }
 
     let (_, output_path) = output_temp.tempfile()?.keep()?;
 
@@ -65,12 +66,19 @@ pub fn run(language: Language, program: &str) -> Result<Assert, Box<dyn Error>> 
     // arguments.
 
     let compiler = build.try_get_compiler()?;
-
     let mut command = Command::new(compiler.path());
-    command.args(compiler.args());
-    command.arg(input_path.clone()); // the input must come first
-    command_add_compiler_flags(&mut command, &variables);
-    command_add_output_file(&mut command, &output_path, msvc, compiler.is_like_clang());
+
+    if msvc {
+        command.args(compiler.args());
+        command_add_compiler_flags(&mut command, &variables);
+        command_add_output_file(&mut command, &output_path, msvc, compiler.is_like_clang());
+        command.arg(input_path.clone());
+    } else {
+        command.arg(input_path.clone()); // the input must come first
+        command.args(compiler.args());
+        command_add_compiler_flags(&mut command, &variables);
+        command_add_output_file(&mut command, &output_path, msvc, compiler.is_like_clang());
+    }
 
     command.envs(variables.clone());
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -66,14 +66,18 @@ pub fn run(language: Language, program: &str) -> Result<Assert, Box<dyn Error>> 
     // arguments.
 
     let compiler = build.try_get_compiler()?;
-    let mut command = Command::new(compiler.path());
+    let mut command;
 
     if msvc {
-        command.args(compiler.args());
+        command = compiler.to_command();
+
         command_add_compiler_flags(&mut command, &variables);
         command_add_output_file(&mut command, &output_path, msvc, compiler.is_like_clang());
         command.arg(input_path.clone());
+        command.envs(variables.clone());
     } else {
+        command = Command::new(compiler.path());
+
         command.arg(input_path.clone()); // the input must come first
         command.args(compiler.args());
         command_add_compiler_flags(&mut command, &variables);

--- a/src/run.rs
+++ b/src/run.rs
@@ -32,6 +32,8 @@ pub fn run(language: Language, program: &str) -> Result<Assert, Box<dyn Error>> 
     let host = target_lexicon::HOST.to_string();
     let target = &host;
 
+    let msvc = target.contains("msvc");
+
     let (_, input_path) = program_file.keep()?;
     let mut output_temp = tempfile::Builder::new();
     let output_temp = output_temp.prefix("inline-c-rs-");
@@ -63,17 +65,13 @@ pub fn run(language: Language, program: &str) -> Result<Assert, Box<dyn Error>> 
     // arguments.
 
     let compiler = build.try_get_compiler()?;
-    let mut command = compiler.to_command();
 
+    let mut command = Command::new(compiler.path());
+    command.arg(input_path.clone()); // the input must come first
+    command.args(compiler.args());
     command_add_compiler_flags(&mut command, &variables);
+    command_add_output_file(&mut command, &output_path, msvc, compiler.is_like_clang());
 
-    {
-        let msvc = target.contains("msvc");
-        let clang = compiler.is_like_clang();
-        command_add_output_file(&mut command, &output_path, msvc, clang);
-    }
-
-    command.arg(&input_path);
     command.envs(variables.clone());
 
     let clang_output = command.output()?;


### PR DESCRIPTION
For instance, the following will fail:

```
cc -I<…> -L<…> -Wl,l<…> -o test test.c
```

But the following will work:

```
cc test.c -I<…> -L<…> -Wl,l<…> -o test
```

This patch puts the input path first, before everything.