### PR TITLE
feat: Support `#define` (nightly only)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: Build and Test
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   # The `test` job.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   # The `test` job.
   test:
-    name: Test
+    name: Test (stable)
 
     strategy:
       matrix:
@@ -26,6 +26,56 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+          default: true
+          override: true
+
+      - name: Cache Cargo registry
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ matrix.target }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache Cargo bin
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/bin
+          key: ${{ matrix.target }}-cargo-bin-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache Cargo build
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: ${{ matrix.target }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Run the tests
+        shell: bash
+        run: |
+          cargo build --release
+          cargo test --release -- --nocapture
+
+  # The `test-nightly` job.
+  test:
+    name: Test (nightly)
+
+    strategy:
+      matrix:
+        target: [
+          ubuntu-latest,
+          macos-latest,
+          windows-latest
+        ]
+      fail-fast: false
+
+    runs-on: ${{ matrix.target }}
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
           default: true
           override: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
           cargo test --release -- --nocapture
 
   # The `test-nightly` job.
-  test:
+  test-nightly:
     name: Test (nightly)
 
     strategy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ target-lexicon = "0.11"
 assert_cmd = "1.0"
 predicates = "1.0"
 
+[build-dependencies]
+rustc_version = "0.3"
+
 [workspace]
 members = [
     "macros",

--- a/README.md
+++ b/README.md
@@ -333,6 +333,8 @@ directive.
 * [Cargo C](https://github.com/lu-zero/cargo-c), to build and install
   C-compatible libraries; it configures `inline-c` for you when using
   `cargo ctest`!
+* [Biscuit](https://github.com/CleverCloud/biscuit-rust), an
+  authorization token microservices architectures.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -301,6 +301,31 @@ rules are applied, rather than the C ruleset. [See this issue on
 `rustdoc` to follow the
 fix](https://github.com/rust-lang/rust/issues/78917).
 
+### C macros
+
+C macros with the `#define` directive is supported only with Rust
+nightly. One can write:
+
+```rust,ignore
+use inline_c::assert_c;
+
+fn test_c_macro() {
+    (assert_c! {
+        #define sum(a, b) ((a) + (b))
+
+        int main() {
+            return !(sum(1, 2) == 3);
+        }
+    })
+    .success();
+}
+```
+
+Note that multi-lines macros don't work! That's because the `\` symbol
+is consumed by the Rust lexer. The best workaround is to define the
+macro in another `.h` file, and to include it with the `#include`
+directive.
+
 ## Who is using it?
 
 * [Wasmer](https://github.com/wasmerio/wasmer), the leading

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    if rustc_version::version_meta().unwrap().channel == rustc_version::Channel::Nightly {
+        println!("cargo:rustc-cfg=nightly");
+    }
+}

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -15,5 +15,8 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0"
+proc-macro2 = { version = "1.0", features = [ "span-locations" ] }
 quote = "1.0"
+
+[build-dependencies]
+rustc_version = "0.3"

--- a/macros/build.rs
+++ b/macros/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    if rustc_version::version_meta().unwrap().channel == rustc_version::Channel::Nightly {
+        println!("cargo:rustc-cfg=nightly");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -310,6 +310,31 @@
 //! of rules are applied, rather than the C ruleset. [See this issue
 //! on `rustdoc` to follow the
 //! fix](https://github.com/rust-lang/rust/issues/78917).
+//!
+//! ## C macros
+//!
+//! C macros with the `#define` directive is supported only with Rust
+//! nightly. One can write:
+//!
+//! ```rust,ignore
+//! use inline_c::assert_c;
+//!
+//! fn test_c_macro() {
+//!     (assert_c! {
+//!         #define sum(a, b) ((a) + (b))
+//!
+//!         int main() {
+//!             return !(sum(1, 2) == 3);
+//!         }
+//!     })
+//!     .success();
+//! }
+//! ```
+//!
+//! Note that multi-lines macros don't work! That's because the `\` symbol
+//! is consumed by the Rust lexer. The best workaround is to define the
+//! macro in another `.h` file, and to include it with the `#include`
+//! directive.
 
 mod assert;
 mod run;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -463,4 +463,17 @@ mod tests {
         remove_var("INLINE_C_RS_HELLO");
         remove_var("INLINE_C_RS_CFLAGS");
     }
+
+    #[cfg(nightly)]
+    #[test]
+    fn test_c_macro_with_define() {
+        (assert_c! {
+            #define sum(a, b) ((a) + (b))
+
+            int main() {
+                return !(sum(1, 2) == 3);
+            }
+        })
+        .success();
+    }
 }


### PR DESCRIPTION
To support the `#define` directive in C, we need the `proc_macro_span`
feature of Rust, which is available only in nightly for the moment
(see https://github.com/rust-lang/rust/issues/54725).

Fix https://github.com/Hywan/inline-c-rs/issues/5.