### PR TITLE
Skip optimizations

### DIFF
--- a/src/run.rs
+++ b/src/run.rs
@@ -54,8 +54,7 @@ pub fn run(language: Language, program: &str) -> Result<Assert, Box<dyn Error>> 
         .warnings_into_errors(true)
         .debug(false)
         .host(&host)
-        .target(target)
-        .opt_level(2);
+        .target(target);
 
     if let Language::Cxx = language {
         build = build.cpp(true);


### PR DESCRIPTION
Since the crate is run mainly for testing, we can skip any optimizations as they usually take compilation time and the runtime cost is of removing optimizations is negligible.