### PR TITLE
Use predicates 2 to drop unmainted diff library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ lazy_static = "1.4"
 cc = "1.0"
 target-lexicon = "0.11"
 assert_cmd = "1.0"
-predicates = "1.0"
+predicates = "2"
 
 [build-dependencies]
 rustc_version = "0.3"


### PR DESCRIPTION
See https://rustsec.org/advisories/RUSTSEC-2020-0095.