### PR TITLE
Expose output_path

### DIFF
--- a/src/assert.rs
+++ b/src/assert.rs
@@ -5,13 +5,15 @@ use std::{fs, path::PathBuf, process::Command};
 pub struct Assert {
     command: assert_cmd::Command,
     files_to_remove: Option<Vec<PathBuf>>,
+    output_path: PathBuf,
 }
 
 impl Assert {
-    pub(crate) fn new(command: Command, files_to_remove: Option<Vec<PathBuf>>) -> Self {
+    pub(crate) fn new(command: Command, files_to_remove: Option<Vec<PathBuf>>, output_path: PathBuf) -> Self {
         Self {
             command: assert_cmd::Command::from_std(command),
-            files_to_remove,
+            files_to_remove: files_to_remove,
+            output_path: output_path
         }
     }
 
@@ -27,6 +29,10 @@ impl Assert {
     /// Shortcut to `self.assert().failure()`.
     pub fn failure(&mut self) -> assert_cmd::assert::Assert {
         self.assert().failure()
+    }
+
+    pub fn output_path(&self) -> &PathBuf {
+        &self.output_path
     }
 }
 

--- a/src/run.rs
+++ b/src/run.rs
@@ -98,13 +98,13 @@ pub fn run(language: Language, program: &str) -> Result<Assert, Box<dyn Error>> 
     let clang_output = command.output()?;
 
     if !clang_output.status.success() {
-        return Ok(Assert::new(command, Some(files_to_remove)));
+        return Ok(Assert::new(command, Some(files_to_remove), output_path));
     }
 
-    let mut command = Command::new(output_path);
+    let mut command = Command::new(output_path.clone());
     command.envs(variables);
 
-    Ok(Assert::new(command, Some(files_to_remove)))
+    Ok(Assert::new(command, Some(files_to_remove), output_path))
 }
 
 fn collect_environment_variables<'p>(program: &'p str) -> (Cow<'p, str>, HashMap<String, String>) {


### PR DESCRIPTION
This is a small change that exposes the output_path.

I'm working on some code right now that compiles the inline c code as a shared object. I want to use something like libloading to later load the shared library and work with it, but to do that I need the output_path. This commit just exposes that via Assert. 